### PR TITLE
Add proper command line argument parsing.

### DIFF
--- a/neat.cabal
+++ b/neat.cabal
@@ -14,7 +14,8 @@ Cabal-version:         >= 1.8
 Executable neat
   Main-is:             Main.hs
   hs-source-dirs:      app
-  Build-Depends:       base, filepath, neat, parsec
+  Build-Depends:       base, filepath, neat,
+                       optparse-applicative >= 0.11 && < 0.12
 
 Library
   Build-depends:       base >= 4 && < 5, filepath, parsec


### PR DESCRIPTION
Parse command line arguments using `optparse-applicative`.

This adds the following help message:

```
$ neat --help
Usage: neat (--hs | --xml | --xslt) [FILE]

Available options:
  -h,--help                Show this help text
  --hs                     Generate Haskell output.
  --xml                    Generate XML output.
  --xslt                   Generate XSLT output.
  FILE                     Input file. Defaults to stdin.
```
